### PR TITLE
Fix inconsistent use of tabs and spaces in indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Set default charset
+[*.{py,md,txt,json,yml}]
+charset = utf-8
+
+# 2 space indentation
+[*.py]
+indent_style = space
+indent_size = 2

--- a/g2p_seq2seq/data_utils.py
+++ b/g2p_seq2seq/data_utils.py
@@ -179,7 +179,7 @@ def collect_pronunciations(dic_lines):
       else:
         dic[lst[0]].append(" ".join(lst[1:]))
     elif len(lst) == 1:
-	print("WARNING: No phonemes for word '%s' line ignored" % (lst[0]))
+      print("WARNING: No phonemes for word '%s' line ignored" % (lst[0]))
   return dic
 
 

--- a/g2p_seq2seq/g2p.py
+++ b/g2p_seq2seq/g2p.py
@@ -171,8 +171,8 @@ class G2PModel(object):
     """Train a gr->ph translation model using G2P data."""
 
     if hasattr(self, 'model'):
-	print("Model already exists in", self.model_dir)
-	return
+      print("Model already exists in", self.model_dir)
+      return
 
     self.__train_init(params, train_path, valid_path, test_path)
 
@@ -340,8 +340,8 @@ class G2PModel(object):
     test_dic = data_utils.collect_pronunciations(test_lines)
     
     if len(test_dic) < 1:
-	print("Test dictionary is empty")
-	return
+      print("Test dictionary is empty")
+      return
 
     print('Beginning calculation word error rate (WER) on test sample.')
     errors = self.calc_error(test_dic)


### PR DESCRIPTION
On Python3 mixing tabs and spaces causes the `TabError` exception.

Additionally include a `.editorconfig` file to help maintain consistent coding style.