### PR TITLE
Stop criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ And, if you want to start training from scratch:
   "--reinit" - Rewrite model in model_folder_path
 ```
 
+To reproduce the following results, set:
+```
+# for the model with size 64:
+--max_steps 80000
+# for the model with size 512:
+--max_steps 150000
+```
+
 #### Word error rate on CMU dictionary data sets
 
 System | WER ([CMUdict PRONALSYL 2007](https://sourceforge.net/projects/cmusphinx/files/G2P%20Models/phonetisaurus-cmudict-split.tar.gz)), % | WER ([CMUdict latest\*](https://github.com/cmusphinx/cmudict)), %

--- a/g2p_seq2seq/g2p.py
+++ b/g2p_seq2seq/g2p.py
@@ -241,12 +241,12 @@ class G2PModel(object):
             and train_loss > max(prev_train_losses[-3:])):
           self.session.run(self.model.learning_rate_decay_op)
 
-        if (len(prev_valid_losses) > 0
-            and eval_loss <= min(prev_valid_losses)):
+        #if (len(prev_valid_losses) > 0
+        #    and eval_loss <= min(prev_valid_losses)):
           # Save checkpoint and zero timer and loss.
-          self.model.saver.save(self.session,
-                                os.path.join(self.model_dir, "model"),
-                                write_meta_graph=False)
+        self.model.saver.save(self.session,
+                              os.path.join(self.model_dir, "model"),
+                              write_meta_graph=False)
 
         # Stop train if no improvement was seen on validation set
         # over last 35 times


### PR DESCRIPTION
Add new stop criteria. Previously number of the allowable number of epochs without improvement was fixed. Training stopped if no improvement was seen during this window. New stop criteria include possibility of increasing of that window depending on the number of epochs needed for previous improvements during training.