### PR TITLE
fixed python 2 to python 3 errors

### DIFF
--- a/g2p_seq2seq/g2p.py
+++ b/g2p_seq2seq/g2p.py
@@ -199,7 +199,7 @@ class G2PModel(object):
     assert len(self.inputs) < const_array_size
     self.inputs += [0] * (const_array_size - len(self.inputs))
 
-    result = self.res_iter.next()
+    result = next(self.res_iter)
     pronunciations = []
     if self.decode_hp.return_beams:
       beams = np.split(result["outputs"], self.decode_hp.beam_size, axis=0)

--- a/g2p_seq2seq/g2p_encoder.py
+++ b/g2p_seq2seq/g2p_encoder.py
@@ -97,7 +97,7 @@ class GraphemePhonemeEncoder(text_encoder.TextEncoder):
       """Symbols generator for vocab initializer from file."""
       with tf.gfile.Open(filename) as vocab_file:
         for line in vocab_file:
-          sym = line.decode("utf-8").strip()
+          sym = line.strip()
           yield sym
 
     self._init_vocab(sym_gen(), add_reserved_symbols=False)
@@ -160,7 +160,7 @@ def build_vocab_list(data_path, init_vocab_list=[]):
   vocab = {item:1 for item in init_vocab_list}
   with tf.gfile.GFile(data_path, "r") as data_file:
     for line in data_file:
-      items = line.decode("utf-8").strip().split()
+      items = line.strip().split()
       vocab.update({char:1 for char in list(items[0])})
       vocab.update({phoneme:1 for phoneme in items[1:]})
     vocab_list = [PAD, EOS]

--- a/tests/g2p_unittest.py
+++ b/tests/g2p_unittest.py
@@ -2,13 +2,12 @@
 import unittest
 import shutil
 import sys
+import os
 sys.path.insert(0, '/Users/zhanwenchen/projects/g2p-seq2seq')
 from g2p_seq2seq import g2p
 import g2p_seq2seq.g2p_trainer_utils as g2p_trainer_utils
 from g2p_seq2seq.g2p import G2PModel
 from g2p_seq2seq.params import Params
-import inspect, os
-
 
 class TestG2P(unittest.TestCase):
 
@@ -23,7 +22,8 @@ class TestG2P(unittest.TestCase):
     g2p_model = G2PModel(params, train_path=train_path, dev_path=dev_path,
                          test_path=dev_path)
     g2p_model.train()
-    shutil.rmtree(model_dir)
+
+    shutil.rmtree(model_dir, ignore_errors=True)
 
   def test_decode(self):
     model_dir = os.path.abspath("tests/models/decode")


### PR DESCRIPTION
There were a few things that weren't working due to old python 2 notation. I fixed them and now it runs on my machine! The g2p_encoder.py and g2p_unittest.py both made 'python setup.py test' fail, and the error in g2p.py made the interactive model fail when typing anything in.  Most of this is talked about in issue #129 